### PR TITLE
fix php unit compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "phpunit/phpunit": "^8|^9"
+        "phpunit/phpunit": "^8.5|^9"
     }
 }


### PR DESCRIPTION
- PHPUnit\Framework\MockObject\Rule\InvokedCount don't exists until phpunit 8.5 
- PHPUnit\Framework\MockObject\Rule\InvocationOrder don't exists until php unit 8.5
